### PR TITLE
Use per-build variant content hashes in the lockfile

### DIFF
--- a/src/hf_kernels/cache.py
+++ b/src/hf_kernels/cache.py
@@ -1,0 +1,4 @@
+from typing import Optional
+import os
+
+CACHE_DIR: Optional[str] = os.environ.get("HF_KERNELS_CACHE", None)

--- a/src/hf_kernels/cli.py
+++ b/src/hf_kernels/cli.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from hf_kernels.compat import tomllib
 from hf_kernels.lockfile import KernelLock, get_kernel_locks
-from hf_kernels.utils import install_kernel, install_kernel_all_variants
+from hf_kernels.utils import build_variant, install_kernel, install_kernel_all_variants
 
 
 def main():
@@ -59,10 +59,16 @@ def download_kernels(args):
             file=sys.stderr,
         )
         if args.all_variants:
-            install_kernel_all_variants(kernel_lock.repo_id, kernel_lock.sha)
+            install_kernel_all_variants(
+                kernel_lock.repo_id, kernel_lock.sha, variant_locks=kernel_lock.variants
+            )
         else:
             try:
-                install_kernel(kernel_lock.repo_id, kernel_lock.sha)
+                install_kernel(
+                    kernel_lock.repo_id,
+                    kernel_lock.sha,
+                    variant_locks=kernel_lock.variants,
+                )
             except FileNotFoundError as e:
                 print(e, file=sys.stderr)
                 all_successful = False

--- a/src/hf_kernels/hash.py
+++ b/src/hf_kernels/hash.py
@@ -1,0 +1,31 @@
+from typing import List, Tuple
+import hashlib
+import os
+from pathlib import Path
+
+
+def content_hash(dir: Path) -> str:
+    """Get a hash of the contents of a directory."""
+
+    # Get the file paths. The first element is a byte-encoded relative path
+    # used for sorting. The second element is the absolute path.
+    paths: List[Tuple[bytes, Path]] = []
+    # Ideally we'd use Path.walk, but it's only available in Python 3.12.
+    for dirpath, _, filenames in os.walk(dir):
+        for filename in filenames:
+            file_abs = Path(dirpath) / filename
+
+            # Python likes to create files when importing modules from the
+            # cache, only hash files that are symlinked blobs.
+            if file_abs.is_symlink():
+                paths.append(
+                    (file_abs.relative_to(dir).as_posix().encode("utf-8"), file_abs)
+                )
+
+    m = hashlib.sha256()
+    for filename, path in sorted(paths):
+        m.update(filename)
+        with open(path, "rb") as f:
+            m.update(f.read())
+
+    return f"sha256-{m.hexdigest()}"

--- a/tests/hash_validation/hf-kernels.lock
+++ b/tests/hash_validation/hf-kernels.lock
@@ -1,0 +1,56 @@
+[
+  {
+    "repo_id": "kernels-community/activation",
+    "sha": "6a030420d0dd33ffdc1281afc8ae8e94b4f4f9d0",
+    "variants": {
+      "torch25-cxx98-cu124-x86_64-linux": {
+        "hash": "sha256-fc465a135358badf9670792fff90b171623cad84989e2397d9edd2c3c2b036f0",
+        "hash_type": "recursive_file_hash"
+      },
+      "torch25-cxx11-cu121-x86_64-linux": {
+        "hash": "sha256-c9aae75c623e20c16c19fc0d6bf7b9b67823d03dd502c80e39d9c0534fbf0fc0",
+        "hash_type": "recursive_file_hash"
+      },
+      "torch26-cxx11-cu118-x86_64-linux": {
+        "hash": "sha256-dcc1141a70845c5ae20b953cbc8496c265b158ebed8d31c037119f286ff62e06",
+        "hash_type": "recursive_file_hash"
+      },
+      "torch25-cxx98-cu118-x86_64-linux": {
+        "hash": "sha256-8ab0577ecf1a96ea6b55b60ed95bc3c02595fdefedf67967b68b93a22c5978d5",
+        "hash_type": "recursive_file_hash"
+      },
+      "torch25-cxx11-cu124-x86_64-linux": {
+        "hash": "sha256-d0cb59cb5cda691f212004e59a89168d5756ae75888be2cd5ca7b470402d5927",
+        "hash_type": "recursive_file_hash"
+      },
+      "torch26-cxx11-cu124-x86_64-linux": {
+        "hash": "sha256-e3f4adcb205fa00c6a16e2c07dd21f037d31165c1b92fdcf70b9038852e2a8ad",
+        "hash_type": "recursive_file_hash"
+      },
+      "torch26-cxx98-cu126-x86_64-linux": {
+        "hash": "sha256-6ebc15cccd9c61eef186ba6d288c72839f7d5a51bf1a46fafec5d673417c040f",
+        "hash_type": "recursive_file_hash"
+      },
+      "torch25-cxx98-cu121-x86_64-linux": {
+        "hash": "sha256-075bf0f2e208ffd76d219c4f6cea80ba5e1ee2fd9f172786b5e681cbf4d494f7",
+        "hash_type": "recursive_file_hash"
+      },
+      "torch26-cxx98-cu118-x86_64-linux": {
+        "hash": "sha256-51edd32659cef0640ee128228c0478e1b7068b4182075a41047ee288bcaa05a0",
+        "hash_type": "recursive_file_hash"
+      },
+      "torch26-cxx98-cu124-x86_64-linux": {
+        "hash": "sha256-6dddf50d68b9f94bdf101571080b74fa50d084a1e3ac10f7e1b4ff959cb2685f",
+        "hash_type": "recursive_file_hash"
+      },
+      "torch26-cxx11-cu126-x86_64-linux": {
+        "hash": "sha256-a9cac68d9722bb809267777f481522efc81980e237207e5b998926f1c5c88108",
+        "hash_type": "recursive_file_hash"
+      },
+      "torch25-cxx11-cu118-x86_64-linux": {
+        "hash": "sha256-cdc3b4142939f1ad8ac18865c83ac69fc0450f46d3dcb5507f2a69b6a292fb70",
+        "hash_type": "recursive_file_hash"
+      }
+    }
+  }
+]

--- a/tests/hash_validation/pyproject.toml
+++ b/tests/hash_validation/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.kernels.dependencies]
+"kernels-community/activation" = ">=0.0.2"

--- a/tests/test_hash_validation.py
+++ b/tests/test_hash_validation.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+from hf_kernels.cli import download_kernels
+
+
+# Mock download arguments class.
+@dataclass
+class DownloadArgs:
+    all_variants: bool
+    project_dir: Path
+
+
+def test_download_hash_validation():
+    project_dir = Path(__file__).parent / "hash_validation"
+    download_kernels(DownloadArgs(all_variants=False, project_dir=project_dir))
+
+
+def test_download_all_hash_validation():
+    project_dir = Path(__file__).parent / "hash_validation"
+    download_kernels(DownloadArgs(all_variants=True, project_dir=project_dir))


### PR DESCRIPTION
This makes the lock file a fair bit shorter than per-file hashes. They can also be verified without any knowledge of Git objects, etc.

**Draft:** we probably want to use the git SHA hashes, PR soon.